### PR TITLE
Add default manifest.yml

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,8 @@
+applications:
+- name: ras-backstage
+  buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git
+  disk_quota: 1G
+  instances: 1
+  memory: 512M
+  stack: cflinuxfs2
+  timeout: 180


### PR DESCRIPTION
Add manifest file for cloudfoundry deployments

Are the defaults set to sensible values?
Are we missing any manifest properties that should be there?
Could we strip them down further?